### PR TITLE
Fixed safari @click not working

### DIFF
--- a/frontend/components/GuessInput.vue
+++ b/frontend/components/GuessInput.vue
@@ -39,6 +39,7 @@
               @keydown.up.prevent="focusPrevAutocompleteButton"
               @focusout="unfocusInput"
               @click="autocompleteItemClicked(name_item)"
+              @mousedown="autocompleteItemClicked(name_item)"
             >
               <span class="block ml-1 truncate">{{
                 name_item.local_name
@@ -136,6 +137,7 @@ const debouncedNameInput = _.debounce((event) => {
 })
 
 function autocompleteItemClicked(name_item: LocalName) {
+  console.log('autocompleteItemClicked called');
   name.value = name_item.local_name
   isCloseAutocomplete.value = true
   nameInput.value?.focus()

--- a/frontend/components/GuessInput.vue
+++ b/frontend/components/GuessInput.vue
@@ -137,7 +137,6 @@ const debouncedNameInput = _.debounce((event) => {
 })
 
 function autocompleteItemClicked(name_item: LocalName) {
-  console.log('autocompleteItemClicked called');
   name.value = name_item.local_name
   isCloseAutocomplete.value = true
   nameInput.value?.focus()


### PR DESCRIPTION
There was a known issue that click event not working on safari. 
https://stackoverflow.com/questions/50566882/safari-doesnt-fire-click-event-on-select-element-on-time

So I added a mousedown event below click event.

close https://github.com/yf-dev/pokemantle/issues/21